### PR TITLE
Fix for sleep duration issue

### DIFF
--- a/convertors.py
+++ b/convertors.py
@@ -213,7 +213,7 @@ class Convertor:
 		return dict(
 			dataTypeName='com.google.activity.segment',
 			startTimeNanos=epoch_time_nanos,
-			endTimeNanos=epoch_time_nanos+110,
+			endTimeNanos=epoch_time_nanos+60000000000,
 			value=[dict(intVal=sleepType)]
 			)
 


### PR DESCRIPTION
The sleep segment duration was 110 nanoseconds. Changed to 60 seconds. Sleep reports correctly in Google Fit. Issue praveendath92/fitbit-googlefit#11 is resolved. 