### PR TITLE
Use oauth2client v3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ fitbit>=0.2.2
 google_api_python_client>=1.5.1
 configparser>=3.5.0
 parsedatetime>=2.1
+oauth2client>=3.0,<4.0


### PR DESCRIPTION
I ran into this warning and import errors setting things up:

```
WARNING:googleapiclient.discovery_cache:file_cache is unavailable when using oauth2client >= 4.0.0
ImportError: No module named 'oauth2client.contrib.locked_file'
ImportError: No module named 'oauth2client.locked_file'
ImportError: file_cache is unavailable when using oauth2client >= 4.0.0
```

Installing oauth2client v3.0.0 fixed the issue, so I've change that in the requirements.txt
