### PR TITLE
Fix to allow retry after API Limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from datetime import timedelta, date
 from helpers import *
 from convertors import *
 from remote import *
+from sys import exit
 
 VERSION = "0.3"
 DATE_FORMAT = "%Y-%m-%d"
@@ -104,12 +105,17 @@ def main():
 		remote.SyncFitbitActivitiesToGoogleFit(start_date=start_date)
 
 if __name__ == '__main__':
-	print('')
-	main()
-	print('')
-	print('--------------------------------------------------------------------------')
-	print('                                     Like it ?                            ')
-	print('star the repository : https://github.com/praveendath92/fitbit-googlefit')
-	print('--------------------------------------------------------------------------')
-	print('')
-
+	try:
+		print('')
+		main()
+		print('')
+		print('--------------------------------------------------------------------------')
+		print('                                     Like it ?                            ')
+		print('star the repository : https://github.com/praveendath92/fitbit-googlefit')
+		print('--------------------------------------------------------------------------')
+		print('')
+	except KeyboardInterrupt:
+		print('')
+		print('Stopping...')
+		print('')
+		exit(0)

--- a/remote.py
+++ b/remote.py
@@ -19,6 +19,7 @@ from oauth2client.file import Storage
 from oauth2client.client import OAuth2Credentials
 from googleapiclient.errors import HttpError
 
+from random import randint
 from app import DATE_FORMAT
 
 class Remote:
@@ -53,12 +54,14 @@ class Remote:
 		try:
 		 	resp = api_call(*args,**kwargs)
 		except HTTPTooManyRequests as e:
+			# retry between 5-10 minutes after the hour
+			seconds_till_retry = e.retry_after_secs + randint(300,600)
 			print('')
 			print('-------------------- Fitbit API rate limit reached -------------------')
-			retry_time = datetime.now()+timedelta(seconds=e.retry_after_secs)
+			retry_time = datetime.now()+timedelta(seconds=seconds_till_retry)
 			print('Will retry at {}'.format(retry_time.strftime('%H:%M:%S')))
 			print('')
-			time.sleep(e.retry_after_secs)
+			time.sleep(seconds_till_retry)
 			resp = self.ReadFromFitbit(api_call,*args,**kwargs)
 		return resp
 


### PR DESCRIPTION
This allows it to successfully retry after hitting the API Limit if there is a small difference between the computer's time and Fitbit's server's time. Also exits nicely if you press Ctrl+c while waiting on the retry.

praveendath92/fitbit-googlefit#21