### PR TITLE
Fix cron.sh to "source" the virtualenv

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 cd $(dirname $0)
+source fitbitenv/bin/activate
 python3 app.py
 

--- a/cron.sh
+++ b/cron.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 cd $(dirname $0)
-source fitbitenv/bin/activate
+. fitbitenv/bin/activate
 python3 app.py
 


### PR DESCRIPTION
`cron.sh` originally used the system's python3, not the one installed in the virtualenv. If there were any unmet dependencies on the host system, `cron.sh` would error out. The change sources `fitbitenv/bin/activate` so the following `python3` will be from the virtualenv instead of the host system.