### PR TITLE
Automagically setup, run the authentication scripts, and your first sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,10 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# custom config
+config.ini
+
+#virtualenv
+fitbitenv/
+test.py

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Unlike other alternatives, such as fitnessyncer.com, this aims to offer very fin
 - [x] Heart rate - second level precision
 - [x] Weight
 - [x] Body fat percentage
-- [x] Activities 
+- [x] Activities
   - [x] Running
   - [x] Swimming
   - [x] Biking
@@ -44,11 +44,11 @@ You have to register your own Fitbit and Google Fit applications. This setup is 
 
 1. Run App.py
 -------------------
-This is a python3 application so install all the dependencies 
+This is a python3 application so install all the dependencies
 
-- Make sure you have Python 3.5 or higher installed ```sudo apt update && sudo apt install python3```
+- Make sure you have Python or higher installed ```sudo apt update && sudo apt install python3```
 - Make sure you have Virtualenv installed ```sudo apt install virtualenv```
-- Clone the repository and cd into it (cd where you want it saved at first) ```git clone https://github.com/praveendath92/fitbit-googlefit.git && cd ./fitbit-googlefit```
+- Clone the repository using the link green `Clone or Download` at the top and cd into it (cd where you want it saved at first) ```git clone ***link***``` and ```cd ./fitbit-googlefit```
 - Run app.py ```python3 app.py```
 
 App.py will now create a virtualenv called fitbitenv, source this new virtualenv, and use pip3 to install its necessary dependencies.
@@ -139,7 +139,7 @@ Add above line to your cron tab: ```crontab -e``` in Linux. Sync logs will be st
 ----------------------------
 This program fully supports running headless on a remote server, Raspberry Pi, Digitalocean, etc. Simply answer ```no``` when asked during set if your computer has a native display and browser. Assuming you are SSHed into the remote server, just copy the supplied URLs and paste them into your local browser, and then copy the Redirect URL (Fitbit) and Authentication Code (Google) back into the program.
 
-Note : 
+Note :
 -------
-1. Get command line help using the ```-h``` flag. 
+1. Get command line help using the ```-h``` flag.
 2. Arguments passed through command-line take higher priority over ```config.ini``` values.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ App.py will now create a virtualenv called fitbitenv, source this new virtualenv
 
 2. Edit your config.ini
 -------------------
-App.py will copy ```config.template.ini``` to ```config.ini``` and attempt to open it using either ```$EDITOR```, nano, vim, or vi. If none of those are installed.
+App.py will copy ```config.template.ini``` to ```config.ini``` and attempt to open it using either ```$EDITOR```, nano, vim, or vi.
 
-You will get a chance to press Ctrl+c to stop the script so you can edit ```config.ini```. run ```python app.py``` again after you have edited ```config.ini```, ONLY if you had to press Ctrl+c to manually edit it.
+If none of those are installed, you will get a chance to press Ctrl+c to stop the script so you can edit ```config.ini```. run ```python app.py``` again after you have edited ```config.ini```, ONLY if you had to press Ctrl+c to manually edit it.
 
 Feel free to change any settings in ```config.ini```, and if you mess it up beyond all recognition, just run ```cp -f config.template.ini config.ini``` from the ```fitbit-googlefit``` directory.
 

--- a/README.md
+++ b/README.md
@@ -42,16 +42,27 @@ Unlike other alternatives, such as fitnessyncer.com, this aims to offer very fin
 ----------------------------
 You have to register your own Fitbit and Google Fit applications. This setup is a one time thing.
 
-1. Install dependencies
+1. Run App.py
 -------------------
 This is a python3 application so install all the dependencies 
 
-- Create virtualenv ```virtualenv fitbitenv```
-- Activate env ```source fitbitenv/bin/activate``` 
-- Install dependencies using ```pip3 install -r requirements.txt```
+- Make sure you have Python 3.5 or higher installed ```sudo apt update && sudo apt install python3```
+- Make sure you have Virtualenv installed ```sudo apt install virtualenv```
+- Clone the repository and cd into it (cd where you want it saved at first) ```git clone https://github.com/praveendath92/fitbit-googlefit.git && cd ./fitbit-googlefit```
+- Run app.py ```python3 app.py```
+
+App.py will now create a virtualenv called fitbitenv, source this new virtualenv, and use pip3 to install its necessary dependencies.
 
 
-2. Fitbit setup
+2. Edit your config.ini
+-------------------
+App.py will copy ```config.template.ini``` to ```config.ini``` and attempt to open it using either ```$EDITOR```, nano, vim, or vi. If none of those are installed.
+
+You will get a chance to press Ctrl+c to stop the script so you can edit ```config.ini```. run ```python app.py``` again after you have edited ```config.ini```, ONLY if you had to press Ctrl+c to manually edit it.
+
+Feel free to change any settings in ```config.ini```, and if you mess it up beyond all recognition, just run ```cp -f config.template.ini config.ini``` from the ```fitbit-googlefit``` directory.
+
+3. Fitbit setup
 -------------------
 All instructions below must be performed using the same Fitbit account you want to sync with Google Fit.
 
@@ -59,40 +70,55 @@ All instructions below must be performed using the same Fitbit account you want 
 - Use the information below:
 
 ```
-Application Name : --
-Description : --
-Application Website : --
-Organization : --
-Organization Website : --
-OAuth 2.0 Application Type : **Personal**
-Callback URL : http://localhost:8080/
-Default Access Type : Read-Only
+===========================================================================
+===========================================================================
 
-Note : 
+Go to this site and register a new Fitbit app
+https://dev.fitbit.com/apps/new
+
+
+Application Name :              --Choose a name--
+Description :                   --Choose a description--
+Application Website :           --Your website--
+Organization :                  --Choose an organization--
+Organization Website :          --Your website--
+OAuth 2.0 Application Type :    **Must choose 'Personal'**
+Callback URL :                  http://localhost:8080/
+Default Access Type :           Read-Only
+
+Note :
 1. Use your own information for fields marked --
 2. Make sure you copy the Callback URL exactly (including the last /)
 3. Application Type MUST be Personal
+
+===========================================================================
+===========================================================================
 ```
+
 - Hit save and make a note of ```OAuth 2.0 Client ID``` and ```Client Secret```
-- Navigate to auth folder  ```cd /auth``` 
-- run ```python3 auth_fitbit.py -i <client-id> -s <client-secret>```
-- This opens a popup in the browser. Authenticate and done!
+- Answer the questions that pop up:
+  Does your computer have a native display and browser? yes or no
+      If running headless on a server, select ```no```.
+      If running from a desktop/laptop/Raspberry Pi (with a monitor connected directly to it), select ```yes```
+- If you choose yes, a browser will show up asking you to log in. Authenticate and done!
+- If you choose no, copy the url given into a browser on your phone, desktop, etc. Authenticate and then copy the redirected URL back into the program. Please make double sure that the URLs are exactly the same and you don't miss type anything if you can't copy/paste it.
 
 
-3. Google Fit setup
+4. Google Fit setup
 -------------------
 - Go to the [Google Developers Console](https://console.developers.google.com/flows/enableapi?apiid=fitness)
 - Click ```Continue```. Then select ```Go to credentials``` and select ```Client ID```
 - Under Application type, select ```Other``` and hit ```Create```
 - Make a note of ```client ID``` and ```client secret```
-- Navigate to auth folder ```cd /auth``` 
-- run ```python3 auth_google.py -i <client-id> -s <client-secret>```
-- This opens a popup in the browser. Authenticate and done!
+
+- Copy/Paste your ```Client ID``` and ```Client Secret``` into the program when asked
+- If using the browser method, follow the on screen prompts and you'll be redirected back to the program, authenticated and already preforming your initial sync.
+- If using the headless method, please copy the provided url into a browser and follow the on screen prompts. Google will give you a authentication code, please copy/paste that back into the program when prompted.
 
 
 # Usage
 ----------------------------
-Update the ```config.ini``` with own choices and start the sync using ```python3 app.py```
+Use ```python3 app.py``` to initiate a manual sync.
 
 Sync examples:
 --------------
@@ -111,11 +137,7 @@ Add above line to your cron tab: ```crontab -e``` in Linux. Sync logs will be st
 
 # Headless authentication
 ----------------------------
-If you want to do the authentication process on a system without a display - such as a raspberry pi or a remote server, pass `--console` or `-c` option to the authentication scripts. See below examples.
-
-`python3 auth_fitbit.py -i clientid -s clientsecret --console`
-
-`python3 auth_google.py -i clientid -s clientsecret --console`
+This program fully supports running headless on a remote server, Raspberry Pi, Digitalocean, etc. Simply answer ```no``` when asked during set if your computer has a native display and browser. Assuming you are SSHed into the remote server, just copy the supplied URLs and paste them into your local browser, and then copy the Redirect URL (Fitbit) and Authentication Code (Google) back into the program.
 
 Note : 
 -------

--- a/app.py
+++ b/app.py
@@ -5,15 +5,24 @@ Main class / entry point for the application
 __author__ = "Praveen Kumar Pendyala"
 __email__ = "mail@pkp.io"
 """
-import time,argparse,logging,datetime,dateutil.parser,configparser,json,os,subprocess
+from pathlib import Path
+from shutil import copyfile,which
+import os
+
+fitbitenvloc = Path("./fitbitenv")
+if fitbitenvloc.is_dir() == True:
+	os.system(". ./fitbitenv/bin/activate")
+else:
+	os.system("virtualenv --python=python3 fitbitenv && . ./fitbitenv/bin/activate && pip3 install -r ./requirements.txt")
+
+
+import time,argparse,logging,datetime,dateutil.parser,configparser,json,subprocess
 from datetime import timedelta, date
 from helpers import *
 from convertors import *
 from remote import *
 from sys import exit
-from shutil import copyfile,which
 from time import sleep
-from pathlib import Path
 from auth import auth_fitbit,auth_google
 
 VERSION = "0.3"

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ Main class / entry point for the application
 __author__ = "Praveen Kumar Pendyala"
 __email__ = "mail@pkp.io"
 """
-import time,argparse,logging,datetime,dateutil.parser,configparser,json,os
+import time,argparse,logging,datetime,dateutil.parser,configparser,json,os,subprocess
 from datetime import timedelta, date
 from helpers import *
 from convertors import *
@@ -82,14 +82,14 @@ def main():
 		print("""\n===========================================================================\n===========================================================================\n\nGo to this site and register a new Fitbit app\n https://dev.fitbit.com/apps/new \n\n\nApplication Name :              --Choose a name--\nDescription :                   --Choose a description--\nApplication Website :           --Your website--\nOrganization :                  --Choose an organization--\nOrganization Website :          --Your website--\nOAuth 2.0 Application Type :    **Must choose 'Personal'**\nCallback URL :                  http://localhost:8080/ \nDefault Access Type :           Read-Only\n\nNote :\n1. Use your own information for fields marked --\n2. Make sure you copy the Callback URL exactly (including the last /)\n3. Application Type MUST be Personal\n\nMake a note of your 'OAuth 2.0 Client ID' and 'Client Secret'\n===========================================================================\n===========================================================================\n""")
 		sleep(2)
 		# prompt if on headless or browser
-		isbrowser = get_bool("Does this system have a native display and a browser?")
+		isbrowser = get_bool("Does this system have a native display and a browser? ")
 		fitbitclientid = input("What's your Fitbit Client ID? ")
 		fitbitclientsecret = input("What's your Fitbit Client Secret? ")
 		# run auth/auth_fitbit.py
 		if isbrowser == True:
-			auth_fitbit.main("-i " + fitbitclientid + " -s " + fitbitclientsecret)
+			subprocess.call("cd ./auth && ./auth_fitbit.py -i " + fitbitclientid + " -s " + fitbitclientsecret)
 		else:
-			auth_fitbit.main("-i " + fitbitclientid + " -s " + fitbitclientsecret + " --console")
+			subprocess.call("cd ./auth && ./auth_fitbit.py -i " + fitbitclientid + " -s " + fitbitclientsecret + " --console")
 	# if auth/google.json doesn't exist
 	if googleauthfile.is_file() == False:
 		print("""\n\n===========================================================================\n===========================================================================\n\nGo to https://console.developers.google.com/flows/enableapi?apiid=fitness\n\n1. Click 'Continue'. Then select 'Go to credentials' and select 'Client ID'.\n2. Under 'Application type', select 'Other' and hit 'Create'.\n3. Make a note of 'Client ID' and 'Client Secret'\n\n===========================================================================\n===========================================================================\n""")
@@ -98,14 +98,14 @@ def main():
 		try:
 			isbrowser
 		except NameError:
-			isbrowser = get_bool("Does this system have a native display and a browser?")
+			isbrowser = get_bool("Does this system have a native display and a browser? ")
 		googleclientid = input("What's your Google Client ID? ")
 		googleclientsecret = input("What's your Google Client Secret? ")
 		# run auth/auth_google.py
 		if isbrowser == True:
-			auth_google.main("-i " + googleclientid + " -s " + googleclientsecret)
+			subprocess.call("cd ./auth && ./auth_google.py -i " + googleclientid + " -s " + googleclientsecret)
 		else:
-			auth_google.main("-i " + googleclientid + " -s " + googleclientsecret + " --console")
+			subprocess.call("cd ./auth && ./auth_google.py -i " + googleclientid + " -s " + googleclientsecret + " --console")
 
 
 	# Reading configuration from config file

--- a/app.py
+++ b/app.py
@@ -7,13 +7,15 @@ __email__ = "mail@pkp.io"
 """
 from pathlib import Path
 from shutil import copyfile,which
-import os
+import os,sys
 
 fitbitenvloc = Path("./fitbitenv")
+activate_this = "./fitbitenv/bin/activate_this.py"
 if fitbitenvloc.is_dir() == True:
-	os.system(". ./fitbitenv/bin/activate")
+	exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this))
 else:
 	os.system("virtualenv --python=python3 fitbitenv && . ./fitbitenv/bin/activate && pip3 install -r ./requirements.txt")
+	exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this))
 
 
 import time,argparse,logging,datetime,dateutil.parser,configparser,json,subprocess
@@ -96,9 +98,9 @@ def main():
 		fitbitclientsecret = input("What's your Fitbit Client Secret? ")
 		# run auth/auth_fitbit.py
 		if isbrowser == True:
-			subprocess.call("cd ./auth && ./auth_fitbit.py -i " + fitbitclientid + " -s " + fitbitclientsecret)
+			subprocess.run("cd ./auth && ./auth_fitbit.py -i " + fitbitclientid + " -s " + fitbitclientsecret, shell=True)
 		else:
-			subprocess.call("cd ./auth && ./auth_fitbit.py -i " + fitbitclientid + " -s " + fitbitclientsecret + " --console")
+			subprocess.run("cd ./auth && ./auth_fitbit.py -i " + fitbitclientid + " -s " + fitbitclientsecret + " --console", shell=True)
 	# if auth/google.json doesn't exist
 	if googleauthfile.is_file() == False:
 		print("""\n\n===========================================================================\n===========================================================================\n\nGo to https://console.developers.google.com/flows/enableapi?apiid=fitness\n\n1. Click 'Continue'. Then select 'Go to credentials' and select 'Client ID'.\n2. Under 'Application type', select 'Other' and hit 'Create'.\n3. Make a note of 'Client ID' and 'Client Secret'\n\n===========================================================================\n===========================================================================\n""")
@@ -112,9 +114,9 @@ def main():
 		googleclientsecret = input("What's your Google Client Secret? ")
 		# run auth/auth_google.py
 		if isbrowser == True:
-			subprocess.call("cd ./auth && ./auth_google.py -i " + googleclientid + " -s " + googleclientsecret)
+			subprocess.run("cd ./auth && ./auth_google.py -i " + googleclientid + " -s " + googleclientsecret, shell=True)
 		else:
-			subprocess.call("cd ./auth && ./auth_google.py -i " + googleclientid + " -s " + googleclientsecret + " --console")
+			subprocess.run("cd ./auth && ./auth_google.py -i " + googleclientid + " -s " + googleclientsecret + " --console", shell=True)
 
 
 	# Reading configuration from config file

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from sys import exit
 from shutil import copyfile,which
 from time import sleep
 from pathlib import Path
+from auth import auth_fitbit,auth_google
 
 VERSION = "0.3"
 DATE_FORMAT = "%Y-%m-%d"
@@ -70,9 +71,42 @@ def main():
 	            print("======================================================================\n")
 	            sleep(2)
 	            os.system(editor + " " + str(config))
-	    print("done")
 	except KeyError:
 	    pass
+
+	fitbitauthfile = Path("./auth/fitbit.json")
+	googleauthfile = Path("./auth/google.json")
+	# if auth/fitbit.json doesn't exist
+	if fitbitauthfile.is_file() == False:
+		#send to fitbit's site for authentication
+		print("""\n===========================================================================\n===========================================================================\n\nGo to this site and register a new Fitbit app\n https://dev.fitbit.com/apps/new \n\n\nApplication Name :              --Choose a name--\nDescription :                   --Choose a description--\nApplication Website :           --Your website--\nOrganization :                  --Choose an organization--\nOrganization Website :          --Your website--\nOAuth 2.0 Application Type :    **Must choose 'Personal'**\nCallback URL :                  http://localhost:8080/ \nDefault Access Type :           Read-Only\n\nNote :\n1. Use your own information for fields marked --\n2. Make sure you copy the Callback URL exactly (including the last /)\n3. Application Type MUST be Personal\n\nMake a note of your 'OAuth 2.0 Client ID' and 'Client Secret'\n===========================================================================\n===========================================================================\n""")
+		sleep(2)
+		# prompt if on headless or browser
+		isbrowser = helpers.get_bool("Does this system have a native display and a browser?")
+		fitbitclientid = input("What's your Fitbit Client ID? ")
+		fitbitclientsecret = input("What's your Fitbit Client Secret? ")
+		# run auth/auth_fitbit.py
+		if isbrowser == True:
+			auth_fitbit.main("-i " + fitbitclientid + " -s " + fitbitclientsecret)
+		else
+			auth_fitbit.main("-i " + fitbitclientid + " -s " + fitbitclientsecret + " --console")
+	# if auth/google.json doesn't exist
+	if googleauthfile.is_file() == False:
+		print("""\n\n===========================================================================\n===========================================================================\n\nGo to https://console.developers.google.com/flows/enableapi?apiid=fitness\n\n1. Click 'Continue'. Then select 'Go to credentials' and select 'Client ID'.\n2. Under 'Application type', select 'Other' and hit 'Create'.\n3. Make a note of 'Client ID' and 'Client Secret'\n\n===========================================================================\n===========================================================================\n""")
+		sleep(2)
+		# check if already asked for headless or browser
+		try:
+			isbrowser
+		except NameError:
+			isbrowser = helpers.get_bool("Does this system have a native display and a browser?")
+		googleclientid = input("What's your Google Client ID? ")
+		googleclientsecret = input("What's your Google Client Secret? ")
+		# run auth/auth_google.py
+		if isbrowser == True:
+			auth_google.main("-i " + googleclientid + " -s " + googleclientsecret)
+		else
+			auth_google.main("-i " + googleclientid + " -s " + googleclientsecret + " --console")
+
 
 	# Reading configuration from config file
 	config = configparser.ConfigParser()

--- a/app.py
+++ b/app.py
@@ -96,11 +96,11 @@ def main():
 		isbrowser = get_bool("Does this system have a native display and a browser? ")
 		fitbitclientid = input("What's your Fitbit Client ID? ")
 		fitbitclientsecret = input("What's your Fitbit Client Secret? ")
-		# run auth/auth_fitbit.py
+		# call auth/auth_fitbit.py
 		if isbrowser == True:
-			subprocess.run("cd ./auth && ./auth_fitbit.py -i " + fitbitclientid + " -s " + fitbitclientsecret, shell=True)
+			subprocess.call(["./auth_fitbit.py", "-i", fitbitclientid, "-s", fitbitclientsecret], cwd="./auth")
 		else:
-			subprocess.run("cd ./auth && ./auth_fitbit.py -i " + fitbitclientid + " -s " + fitbitclientsecret + " --console", shell=True)
+			subprocess.call(["./auth_fitbit.py", "-i", fitbitclientid, "-s", fitbitclientsecret, "--console"], cwd="./auth")
 	# if auth/google.json doesn't exist
 	if googleauthfile.is_file() == False:
 		print("""\n\n===========================================================================\n===========================================================================\n\nGo to https://console.developers.google.com/flows/enableapi?apiid=fitness\n\n1. Click 'Continue'. Then select 'Go to credentials' and select 'Client ID'.\n2. Under 'Application type', select 'Other' and hit 'Create'.\n3. Make a note of 'Client ID' and 'Client Secret'\n\n===========================================================================\n===========================================================================\n""")
@@ -112,11 +112,11 @@ def main():
 			isbrowser = get_bool("Does this system have a native display and a browser? ")
 		googleclientid = input("What's your Google Client ID? ")
 		googleclientsecret = input("What's your Google Client Secret? ")
-		# run auth/auth_google.py
+		# call auth/auth_google.py
 		if isbrowser == True:
-			subprocess.run("cd ./auth && ./auth_google.py -i " + googleclientid + " -s " + googleclientsecret, shell=True)
+			subprocess.call(["./auth_google.py", "-i", googleclientid, "-s", googleclientsecret], cwd="./auth")
 		else:
-			subprocess.run("cd ./auth && ./auth_google.py -i " + googleclientid + " -s " + googleclientsecret + " --console", shell=True)
+			subprocess.call(["./auth_google.py", "-i", googleclientid, "-s", googleclientsecret, "--console"], cwd="./auth")
 
 
 	# Reading configuration from config file

--- a/app.py
+++ b/app.py
@@ -94,8 +94,8 @@ def main():
 		sleep(2)
 		# prompt if on headless or browser
 		isbrowser = get_bool("Does this system have a native display and a browser? ")
-		fitbitclientid = input("What's your Fitbit Client ID? ")
-		fitbitclientsecret = input("What's your Fitbit Client Secret? ")
+		fitbitclientid = input("What's your Fitbit Client ID? ").strip()
+		fitbitclientsecret = input("What's your Fitbit Client Secret? ").strip()
 		# call auth/auth_fitbit.py
 		if isbrowser == True:
 			subprocess.call(["./auth_fitbit.py", "-i", fitbitclientid, "-s", fitbitclientsecret], cwd="./auth")
@@ -110,8 +110,8 @@ def main():
 			isbrowser
 		except NameError:
 			isbrowser = get_bool("Does this system have a native display and a browser? ")
-		googleclientid = input("What's your Google Client ID? ")
-		googleclientsecret = input("What's your Google Client Secret? ")
+		googleclientid = input("What's your Google Client ID? ").strip()
+		googleclientsecret = input("What's your Google Client Secret? ").strip()
 		# call auth/auth_google.py
 		if isbrowser == True:
 			subprocess.call(["./auth_google.py", "-i", googleclientid, "-s", googleclientsecret], cwd="./auth")

--- a/app.py
+++ b/app.py
@@ -82,13 +82,13 @@ def main():
 		print("""\n===========================================================================\n===========================================================================\n\nGo to this site and register a new Fitbit app\n https://dev.fitbit.com/apps/new \n\n\nApplication Name :              --Choose a name--\nDescription :                   --Choose a description--\nApplication Website :           --Your website--\nOrganization :                  --Choose an organization--\nOrganization Website :          --Your website--\nOAuth 2.0 Application Type :    **Must choose 'Personal'**\nCallback URL :                  http://localhost:8080/ \nDefault Access Type :           Read-Only\n\nNote :\n1. Use your own information for fields marked --\n2. Make sure you copy the Callback URL exactly (including the last /)\n3. Application Type MUST be Personal\n\nMake a note of your 'OAuth 2.0 Client ID' and 'Client Secret'\n===========================================================================\n===========================================================================\n""")
 		sleep(2)
 		# prompt if on headless or browser
-		isbrowser = helpers.get_bool("Does this system have a native display and a browser?")
+		isbrowser = get_bool("Does this system have a native display and a browser?")
 		fitbitclientid = input("What's your Fitbit Client ID? ")
 		fitbitclientsecret = input("What's your Fitbit Client Secret? ")
 		# run auth/auth_fitbit.py
 		if isbrowser == True:
 			auth_fitbit.main("-i " + fitbitclientid + " -s " + fitbitclientsecret)
-		else
+		else:
 			auth_fitbit.main("-i " + fitbitclientid + " -s " + fitbitclientsecret + " --console")
 	# if auth/google.json doesn't exist
 	if googleauthfile.is_file() == False:
@@ -98,13 +98,13 @@ def main():
 		try:
 			isbrowser
 		except NameError:
-			isbrowser = helpers.get_bool("Does this system have a native display and a browser?")
+			isbrowser = get_bool("Does this system have a native display and a browser?")
 		googleclientid = input("What's your Google Client ID? ")
 		googleclientsecret = input("What's your Google Client Secret? ")
 		# run auth/auth_google.py
 		if isbrowser == True:
 			auth_google.main("-i " + googleclientid + " -s " + googleclientsecret)
-		else
+		else:
 			auth_google.main("-i " + googleclientid + " -s " + googleclientsecret + " --console")
 
 
@@ -172,6 +172,14 @@ def main():
 	#----------------------------------  activity logs  ------------------------
 	if params.getboolean('sync_activities'):
 		remote.SyncFitbitActivitiesToGoogleFit(start_date=start_date)
+
+def get_bool(prompt):
+	"""Prompts for user input that must be either yes or no"""
+	while True:
+		try:
+			return{"yes":True,"Yes":True,"YES":True,"true":True,"True":True,"TRUE":True,"no":False,"No":False,"NO":False,"false":False,"False":False,"FALSE":False}[input(prompt).lower()]
+		except KeyError:
+			print("Invalid input. Please enter either yes or no.")
 
 if __name__ == '__main__':
 	try:

--- a/config.template.ini
+++ b/config.template.ini
@@ -1,6 +1,6 @@
 [params]
 
-# Note: 
+# Note:
 # 1. End date is not respected for activities so, all activities after the start_date will be synced.
 # 2. Examples for date values : today, tomorrow, 2 days ago, 2016-08-19
 # 3. Beaware of Fitbit rate-limiting when doing full sync for periods longer than 3 weeks.

--- a/cron.sh
+++ b/cron.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
 cd $(dirname $0)
-. fitbitenv/bin/activate
 python3 app.py
-

--- a/helpers.py
+++ b/helpers.py
@@ -49,11 +49,3 @@ class Helper(object):
 		for t in ('access_token', 'refresh_token'):
 			credentials[t] = fitbitClient.client.token[t]
 		json.dump(credentials, open(self.fitbitCredsFile, 'w'))
-
-	def get_bool(prompt):
-		"""Prompts for user input that must be either yes or no"""
-		while True:
-			try:
-				return{"yes":True,"Yes":True,"YES":True,"true":True,"True":True,"TRUE":True,"no":False,"No":False,"NO":False,"false":False,"False":False,"FALSE":False}[input(prompt).lower()]
-			except KeyError:
-				print("Invalid input. Please enter either yes or no.")

--- a/helpers.py
+++ b/helpers.py
@@ -26,7 +26,7 @@ class Helper(object):
 	def GetFitbitClient(self):
 		"""Returns an authenticated fitbit client object"""
 		logging.debug("Creating Fitbit client")
-		credentials = json.load(open(self.fitbitCredsFile))  
+		credentials = json.load(open(self.fitbitCredsFile))
 		client = fitbit.Fitbit(**credentials)
 		logging.debug("Fitbit client created")
 		return client
@@ -45,7 +45,15 @@ class Helper(object):
 
 		fitbitClient -- fitbit client object that contains the latest credentials
 		"""
-		credentials = json.load(open(self.fitbitCredsFile)) 
+		credentials = json.load(open(self.fitbitCredsFile))
 		for t in ('access_token', 'refresh_token'):
 			credentials[t] = fitbitClient.client.token[t]
 		json.dump(credentials, open(self.fitbitCredsFile, 'w'))
+
+	def get_bool(prompt):
+		"""Prompts for user input that must be either yes or no"""
+		while True:
+			try:
+				return{"yes":True,"Yes":True,"YES":True,"true":True,"True":True,"TRUE":True,"no":False,"No":False,"NO":False,"false":False,"False":False,"FALSE":False}[input(prompt).lower()]
+			except KeyError:
+				print("Invalid input. Please enter either yes or no.")


### PR DESCRIPTION
Create and source virtualenv and install requirements.txt if fitbitenv doesn't already exist.

Copy config.template.ini to config.ini and open it in an available editor, or press Ctrl+c to stop script and edit in whatever program they want to. Only runs if config.ini doesn't already exist.

Run both Fitbit and Google authentication scripts with directions shown, supporting both browser and headless methods. Only runs if there is no json file for the authentications.

Updated .gitignore to ignore the customized config.ini and the fitbitenv folder.

Updated README.md to give directions based on updated script.
&nbsp;
&nbsp;
&nbsp;
&nbsp;
&nbsp;
&nbsp;
**_# DISCLAIMER_**
_This has been tested on a Chromebook running Debian, both browser method and headless, and a Digitalocean Droplet running Ubuntu headless. I do not have access to a Windows system with python installed, so I don't know how this will react to running in Windows. My understanding of it is that Windows has built in BASH that supports all the standard UNIX style writing (ie folders being separated with / instead of Windows \), so it should in theory work just fine._
&nbsp;
Also, if it wasn't required before, it now requires Python 3.5 or greater for the `subprocess.run()` command