### PR TITLE
Allow overriding the time-of-day Fitbit returns for weighings

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,22 +5,19 @@ Main class / entry point for the application
 __author__ = "Praveen Kumar Pendyala"
 __email__ = "mail@pkp.io"
 """
-import time
 import argparse
 import logging
-import datetime
 import dateutil.parser
 import configparser
 import json
-from datetime import timedelta, date
+from datetime import time
 
-from helpers import *
-from convertors import *
-from remote import *
+from helpers import Helper
+from convertors import Convertor
+from remote import DATE_FORMAT, Remote
 from sys import exit
 
 VERSION = "0.3"
-DATE_FORMAT = "%Y-%m-%d"
 
 def main():
 	# Arguments parsing
@@ -46,7 +43,8 @@ def main():
 
 	# Init objects
 	helper = Helper(args.fitbit_creds, args.google_creds)
-	convertor = Convertor(args.google_creds, params.get('project_number'), None)
+	weighTime = time.fromisoformat(params.get('weigh_time'))
+	convertor = Convertor(args.google_creds, params.get('project_number'), None, weighTime)
 	fitbitClient,googleClient = helper.GetFitbitClient(),helper.GetGoogleClient()
 	remote = Remote(fitbitClient, googleClient, convertor, helper)
 

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,6 @@
 [params]
 
-# Note: 
+# Note:
 # 1. End date is not respected for activities so, all activities after the start_date will be synced.
 # 2. Examples for date values : today, tomorrow, 2 days ago, 2016-08-19
 # 3. Beaware of Fitbit rate-limiting when doing full sync for periods longer than 3 weeks.
@@ -23,6 +23,8 @@ sync_body_fat=1
 sync_activities=1
 sync_sleep=0
 
+# Fitbit always returns 23:59:59 as the time of day for weighing, override:
+weigh_time=23:59:59
 
 # Google Developer Project Number
 project_number=123456789012

--- a/convertors.py
+++ b/convertors.py
@@ -19,7 +19,7 @@ class Convertor:
 	POUNDS_PER_KILOGRAM = 2.20462
 	METERS_PER_MILE = 1609.34
 
-	def __init__(self, googleCredsFile, googleDeveloperProjectNumber, tzinfo):
+	def __init__(self, googleCredsFile, googleDeveloperProjectNumber, tzinfo, weighTime):
 		""" Intialize a convertor object.
 
 		googleCredsFile -- Google Fits credentials file
@@ -28,6 +28,7 @@ class Convertor:
 		self.googleCredsFile = googleCredsFile
 		self.googleDeveloperProjectNumber = googleDeveloperProjectNumber
 		self.tzinfo = tzinfo
+		self.weighTime = weighTime
 
 	def UpdateTimezone(self, tzinfo):
 		"""Update user's timezone info"""
@@ -165,7 +166,7 @@ class Convertor:
 		date -- date to which the data_point belongs to in "yyyy-mm-dd" format
 		data_point -- a single Fitbit intraday weight log data point
 		"""
-		timestamp = "{} {}".format(date, data_point['time'])
+		timestamp = "{} {}".format(date, self.weighTime)
 		epoch_time_nanos = self.nano(self.EpochOfFitbitTimestamp(timestamp))
 		googleWeight = data_point['weight'] / self.POUNDS_PER_KILOGRAM
 

--- a/remote.py
+++ b/remote.py
@@ -20,7 +20,8 @@ from oauth2client.client import OAuth2Credentials
 from googleapiclient.errors import HttpError
 
 from random import randint
-from app import DATE_FORMAT
+
+DATE_FORMAT = "%Y-%m-%d"
 
 class Remote:
 	"""Methods for remote api calls and synchronization from Fitbit to Google Fit"""


### PR DESCRIPTION
Since it only stores one reading per day, and forgets the time,
it always returns 23:59:59, which looks kinda weird in Fit.
For one thing, for today it's usually in the future.
If you weigh yourself in the morning, this'll be off by most of a
day, every day, which I found irritating.

Add a config option to pick your own time-of-day, which is almost certainly closer.