### PR TITLE
Upgrade sleep to use Fitbit v1.2 API

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -26,8 +26,12 @@ class Helper(object):
 	def GetFitbitClient(self):
 		"""Returns an authenticated fitbit client object"""
 		logging.debug("Creating Fitbit client")
-		credentials = json.load(open(self.fitbitCredsFile))  
+		credentials = json.load(open(self.fitbitCredsFile))
 		client = fitbit.Fitbit(**credentials)
+
+		# Use v1.2 sleep API: https://github.com/orcasgit/python-fitbit/issues/128
+		client.API_VERSION = 1.2
+
 		logging.debug("Fitbit client created")
 		return client
 

--- a/remote.py
+++ b/remote.py
@@ -232,17 +232,11 @@ class Remote:
 		# Iterate over each sleep log for that day
 		sleep_count = 0
 		for fit_sleep in fitbitSleeps:
-			minute_points = fit_sleep['minuteData']
+			minute_points = fit_sleep['levels']['data']
 			sleep_count += 1
 
-			# save first time stamp for comparison
-			start_time = minute_points[0]['dateTime']
-			# convert to date, add 1 day, convert back to string
-			next_date_stamp = (datetime.strptime(date_stamp, DATE_FORMAT) + timedelta(1)).strftime(DATE_FORMAT)
-
 			# convert all fitbit data points to google fit data points
-			googlePoints = [self.convertor.ConvertFibitPoint((date_stamp if start_time <= point['dateTime'] else \
-				next_date_stamp),point,'sleep') for point in minute_points]
+			googlePoints = [self.convertor.ConvertFibitPoint(date_stamp,point,'sleep') for point in minute_points]
 
 			# 1. Write a fit session about sleep
 			google_session = self.convertor.ConvertGFitSleepSession(googlePoints, fit_sleep['logId'])


### PR DESCRIPTION
- Fix pre-midnight sleeps being shifted forwards a day, in the new API
  the point includes the full date and time, avoiding the confusion.
- Fix stages being uncategoried, the old code checked for 1/2/3 as ints
  when they were actually strings, the new API includes more types, and
  uses strings.
- I think the new API is also more granular (down to 30s) but less dense
  (it returns one point per stage, and tells you how long it lasted).

Old: https://dev.fitbit.com/build/reference/web-api/sleep-v1
New: https://dev.fitbit.com/build/reference/web-api/sleep

Workaround to enable it:
https://github.com/orcasgit/python-fitbit/issues/128

TODO: switch to the new GFit sleep segment API:
https://developers.google.com/android/reference/com/google/android/gms/fitness/data/SleepStages