### PR TITLE
Add a callback for fitbit token refreshes

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -27,7 +27,9 @@ class Helper(object):
 		"""Returns an authenticated fitbit client object"""
 		logging.debug("Creating Fitbit client")
 		credentials = json.load(open(self.fitbitCredsFile))
-		client = fitbit.Fitbit(**credentials)
+		client = fitbit.Fitbit(
+			refresh_cb = lambda token: self.UpdateFitbitCredentials(token),
+			**credentials)
 
 		# Use v1.2 sleep API: https://github.com/orcasgit/python-fitbit/issues/128
 		client.API_VERSION = 1.2
@@ -44,12 +46,13 @@ class Helper(object):
 		logging.debug("Google client created")
 		return client
 
-	def UpdateFitbitCredentials(self, fitbitClient):
+	def UpdateFitbitCredentials(self, token):
 		"""Persists new fitbit credentials to local storage
 
 		fitbitClient -- fitbit client object that contains the latest credentials
 		"""
-		credentials = json.load(open(self.fitbitCredsFile)) 
+		logging.debug("Refreshed Fitbit token")
+		credentials = json.load(open(self.fitbitCredsFile))
 		for t in ('access_token', 'refresh_token'):
-			credentials[t] = fitbitClient.client.session.token[t]
+			credentials[t] = token[t]
 		json.dump(credentials, open(self.fitbitCredsFile, 'w'))

--- a/remote.py
+++ b/remote.py
@@ -139,9 +139,6 @@ class Remote:
 		dataType -- fitbit data type to sync
 		date_stamp -- timestamp in yyyy-mm-dd format of the day to sync
 		"""
-		# Persist current credentials. Incase the request fails.
-		self.helper.UpdateFitbitCredentials(self.fitbitClient)
-
 		if dataType in ('steps','distance','heart_rate','calories'):
 			return self.SyncFitbitIntradayToGoogleFit(dataType, date_stamp)
 		elif dataType in ('weight','body_fat'):


### PR DESCRIPTION
Without specifying refresh_cb, they don't happen:
- https://python-fitbit.readthedocs.io/en/latest/#fitbit.Fitbit
- https://github.com/orcasgit/python-fitbit/blob/6a0a7cba26c26e6c8096bf51d4cf7f19e113ed96/fitbit/api.py#L179-L183
- https://github.com/orcasgit/python-fitbit/blob/6a0a7cba26c26e6c8096bf51d4cf7f19e113ed96/fitbit/api.py#L151-L152