### PR TITLE
Upgrade to requests 2.30.0 and urllib3 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,9 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyparsing==3.0.9
 python-dateutil==2.8.2
-requests==2.28.1
+requests==2.30.0
 requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0
 uritemplate==4.1.1
-urllib3==1.26.12
+urllib3==2.0.2


### PR DESCRIPTION
Hello, urllib3 maintainer here :wave:

To upgrade to the next release version of urllib3, requests need to be upgraded too, which is something that dependabot does not handle well, see https://github.com/dwoffinden/fitbit-googlefit/pull/144 for an example.